### PR TITLE
Fix for Prototype Pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,12 @@
  * @api public
  */
 
-exports = module.exports = function(a, b){
+exports = module.exports = function (a, b) {
   if (a && b) {
-    for (var key in b) {
-      a[key] = b[key];
+    var allowedAttrs = Object.getOwnPropertyNames(b);
+    console.log(allowedAttrs)
+    for (var allowedAttrs in b) {
+      a[allowedAttrs] = b[allowedAttrs];
     }
   }
   return a;

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@
 exports = module.exports = function (a, b) {
   if (a && b) {
     var allowedAttrs = Object.getOwnPropertyNames(b);
-    console.log(allowedAttrs)
+    
     for (var allowedAttrs in b) {
       a[allowedAttrs] = b[allowedAttrs];
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,51 +1,66 @@
 var merge = require('../index');
 
-describe('merge', function() {
-  
-  describe('an object', function() {
+describe('merge', function () {
+
+  describe('an object', function () {
     var a = { foo: 'bar' }
       , b = { bar: 'baz' };
     var o = merge(a, b);
-    
-    it('should merge properties into first object', function() {
+
+    it('should merge properties into first object', function () {
       expect(Object.keys(a)).to.have.length(2);
       expect(a.foo).to.be.equal('bar');
       expect(a.bar).to.be.equal('baz');
     });
-    
-    it('should return first argument', function() {
+
+    it('should return first argument', function () {
       expect(o).to.be.equal(a);
     });
   });
-  
-  describe('an object with duplicate key', function() {
+
+  describe('an object with duplicate key', function () {
     var a = { foo: 'bar', qux: 'corge' }
       , b = { foo: 'baz' };
     var o = merge(a, b);
-    
-    it('should merge properties into first object', function() {
+
+    it('should merge properties into first object', function () {
       expect(Object.keys(a)).to.have.length(2);
       expect(a.foo).to.be.equal('baz');
       expect(a.qux).to.be.equal('corge');
     });
-    
-    it('should return first argument', function() {
+
+    it('should return first argument', function () {
       expect(o).to.be.equal(a);
     });
   });
-  
-  describe('without a source object', function() {
+
+  describe('without a source object', function () {
     var a = { foo: 'bar' };
     var o = merge(a);
-    
-    it('should leave first object unmodified', function() {
+
+    it('should leave first object unmodified', function () {
       expect(Object.keys(a)).to.have.length(1);
       expect(a.foo).to.be.equal('bar');
     });
-    
-    it('should return first argument', function() {
+
+    it('should return first argument', function () {
       expect(o).to.be.equal(a);
     });
   });
-  
+
+  describe('prototype pollution', function () {
+    var a = { foo: 'bar', qux: 'corge' }
+      , b = {
+        "__proto__": {
+          "polluted": "true",
+        }
+      };
+    var o = merge(a, b);
+
+    it('should leave first object unmodified', function () {
+      expect(o.__proto__.polluted).to.be.equal(undefined);
+    });
+
+  });
+
 });


### PR DESCRIPTION
This commit fixes prototype pollution: https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf

Since so many repos depend on this repo, some may be using it to merge __proto__ and this fix may break them. 